### PR TITLE
Added support for env-based building and deployment

### DIFF
--- a/packages/slate-config/src/path.ts
+++ b/packages/slate-config/src/path.ts
@@ -44,30 +44,6 @@ export type SchemaPaths = {
   /** Source liquid template directory for customers */
   'paths.theme.src.templates.customers':string;
 
-  /** Distribution directory of theme */
-  'paths.theme.dist':string;
-
-  /** Distribution assets directory */
-  'paths.theme.dist.assets':string;
-
-  /** Distribution assets directory */
-  'paths.theme.dist.config':string;
-
-  /** Distribution of theme liquid layout files */
-  'paths.theme.dist.layout':string;
-
-  /** Distribution snippets directory */
-  'paths.theme.dist.snippets':string;
-
-  /** Distribution snippets directory */
-  'paths.theme.dist.locales':string;
-
-  /** Distribution sections directory */
-  'paths.theme.dist.sections':string;
-
-  /** Distribution templates directory */
-  'paths.theme.dist.templates':string;
-
   /** Directory for storing all temporary and/or cache files */
   'paths.theme.cache':string;
 }
@@ -110,29 +86,6 @@ export const SCHEMA_PATHS = slateSchemaCreate<SchemaPaths>(config => ({
 
   'paths.theme.src.templates.customers': () =>
     path.join(config.get('paths.theme.src.templates'), 'customers'),
-
-  'paths.theme.dist': () => path.join(config.get('paths.theme'), 'dist'),
-
-  'paths.theme.dist.assets': () =>
-    path.join(config.get('paths.theme.dist'), 'assets'),
-
-  'paths.theme.dist.config': () =>
-    path.join(config.get('paths.theme.dist'), 'config'),
-
-  'paths.theme.dist.layout': () =>
-    path.join(config.get('paths.theme.dist'), 'layout'),
-
-  'paths.theme.dist.snippets': () =>
-    path.join(config.get('paths.theme.dist'), 'snippets'),
-
-  'paths.theme.dist.locales': () =>
-    path.join(config.get('paths.theme.dist'), 'locales'),
-
-  'paths.theme.dist.sections': () =>
-    path.join(config.get('paths.theme.dist'), 'sections'),
-
-  'paths.theme.dist.templates': () =>
-    path.join(config.get('paths.theme.dist'), 'templates'),
 
   'paths.theme.cache': () =>
     path.join(config.get('paths.theme'), '.cache'),

--- a/packages/slate-env/src/Config.ts
+++ b/packages/slate-env/src/Config.ts
@@ -52,6 +52,30 @@ export type SchemaEnv = SchemaPaths & {
    * Timeout upload is
    */
   'env.keys.timeout':string;
+
+  /** Distribution directory of theme */
+  'paths.theme.dist':string;
+
+  /** Distribution assets directory */
+  'paths.theme.dist.assets':string;
+
+  /** Distribution assets directory */
+  'paths.theme.dist.config':string;
+
+  /** Distribution of theme liquid layout files */
+  'paths.theme.dist.layout':string;
+
+  /** Distribution snippets directory */
+  'paths.theme.dist.snippets':string;
+
+  /** Distribution snippets directory */
+  'paths.theme.dist.locales':string;
+
+  /** Distribution sections directory */
+  'paths.theme.dist.sections':string;
+
+  /** Distribution templates directory */
+  'paths.theme.dist.templates':string;
 }
 
 export const SCHEMA_ENV = slateSchemaCreate<SchemaEnv>(config => ({
@@ -70,6 +94,33 @@ export const SCHEMA_ENV = slateSchemaCreate<SchemaEnv>(config => ({
   'env.keys.themeId': 'SLATE_THEME_ID',
   'env.keys.ignoreFiles': 'SLATE_IGNORE_FILES',
   'env.keys.timeout': 'SLATE_TIMEOUT',
+
+  'paths.theme.dist': () => {
+    const dir = path.join(config.get('paths.theme'), 'dist');
+    const name = process.env[config.get('env.keys.name')] || 'default';
+    return path.join(dir, name);
+  },
+
+  'paths.theme.dist.assets': () =>
+    path.join(config.get('paths.theme.dist'), 'assets'),
+
+  'paths.theme.dist.config': () =>
+    path.join(config.get('paths.theme.dist'), 'config'),
+
+  'paths.theme.dist.layout': () =>
+    path.join(config.get('paths.theme.dist'), 'layout'),
+
+  'paths.theme.dist.snippets': () =>
+    path.join(config.get('paths.theme.dist'), 'snippets'),
+
+  'paths.theme.dist.locales': () =>
+    path.join(config.get('paths.theme.dist'), 'locales'),
+
+  'paths.theme.dist.sections': () =>
+    path.join(config.get('paths.theme.dist'), 'sections'),
+
+  'paths.theme.dist.templates': () =>
+    path.join(config.get('paths.theme.dist'), 'templates'),
 }));
 
 export const config = slateConfigCreate(SCHEMA_ENV);

--- a/packages/slate-sync/src/config.ts
+++ b/packages/slate-sync/src/config.ts
@@ -1,10 +1,11 @@
-import { SchemaPaths, SCHEMA_PATHS, slateConfigCreate, slateSchemaCreate } from '@process-creative/slate-config';
+import { SCHEMA_PATHS, slateConfigCreate, slateSchemaCreate } from '@process-creative/slate-config';
+import { SchemaEnv, SCHEMA_ENV } from '@process-creative/slate-env';
 
-export type SchemaSync = SchemaPaths & {
+export type SchemaSync = SchemaEnv & {
 }
 
 export const SCHEMA_SYNC = slateSchemaCreate<SchemaSync>(config => ({
-  ...SCHEMA_PATHS(config)
+  ...SCHEMA_ENV(config)
 }));
 
 export const config = slateConfigCreate(SCHEMA_SYNC);

--- a/packages/slate-theme/package.json
+++ b/packages/slate-theme/package.json
@@ -6,7 +6,7 @@
     "start": "slate-tools start",
     "watch": "slate-tools start --skipFirstDeploy",
     "build": "slate-tools build",
-    "deploy": "slate-tools build && slate-tools deploy",
+    "deploy": "slate-tools deploy",
     "zip": "slate-tools build && slate-tools zip",
     "open": "slate-tools open",
     "tester": "slate-tools test",

--- a/packages/slate-tools/src/cli/commands/build.ts
+++ b/packages/slate-tools/src/cli/commands/build.ts
@@ -2,28 +2,39 @@
 // production vs development builds
 process.env.NODE_ENV = 'production';
 
+
 /*
- * Run Webpack with the webpack.prod.conf.js configuration file. Write files to disk.
- *
- * If the `deploy` argument has been passed, deploy to Shopify when the compilation is done.
- */
+* Run Webpack with the webpack.prod.conf.js configuration file. Write files to disk.
+*
+* If the `deploy` argument has been passed, deploy to Shopify when the compilation is done.
+*/
 import webpack from 'webpack';
 import webpackConfig from './../../webpack/config/prod';
+import * as slateEnv from '@process-creative/slate-env';
+import minimist from 'minimist';
+import chalk from 'chalk';
+
+const argv = minimist(process.argv.slice(2));
+
+const result = slateEnv.validate();
+if(!result.isValid) {
+  console.log(chalk.red(
+    `Some values in environment '${slateEnv.getEnvNameValue()}' are invalid:`,
+  ));
+  result.errors.forEach((error) => {
+    console.log(chalk.red(`- ${error}`));
+  });
+}
 
 webpack(webpackConfig, (err,stats) => {
   if (err) throw err;
-  
-  process.stdout.write(
-    `${stats.toString({
-      colors: true,
-      modules: false,
-      children: false,
-      chunks: false,
-      chunkModules: false,
-    })}`,
-  );
-
+  console.log(`${stats.toString({
+    colors: true,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false,
+  })}`);
   console.log('');
-
   if (stats.compilation.errors.length) process.exit(1);
 });

--- a/packages/slate-tools/src/cli/commands/deploy.ts
+++ b/packages/slate-tools/src/cli/commands/deploy.ts
@@ -1,19 +1,55 @@
+// Set NODE_ENV so slate.config.js can return different values for
+// production vs development builds
+process.env.NODE_ENV = 'production';
+
+
+/*
+* Run Webpack with the webpack.prod.conf.js configuration file. Write files to disk.
+*
+* If the `deploy` argument has been passed, deploy to Shopify when the compilation is done.
+*/
+import webpack from 'webpack';
+import webpackConfig from './../../webpack/config/prod';
+import * as slateEnv from '@process-creative/slate-env';
 import minimist from 'minimist';
 import chalk from 'chalk';
 import { replace, upload } from '@process-creative/slate-sync';
 import { continueIfPulishedTheme } from '../prompts/continue-if-published-theme';
 
 const argv = minimist(process.argv.slice(2));
-const deploy = argv.replace ? replace : upload;
 
-continueIfPulishedTheme().then((answer: boolean) => {
-  if (!answer) {
-    process.exit(0);
-  }
+const result = slateEnv.validate();
+if(!result.isValid) {
+  console.log(chalk.red(
+    `Some values in environment '${slateEnv.getEnvNameValue()}' are invalid:`,
+  ));
+  result.errors.forEach((error) => {
+    console.log(chalk.red(`- ${error}`));
+  });
+}
 
-  return deploy();
-}).then(() => {
-  return console.log(chalk.green('\nFiles overwritten successfully!\n'));
-}).catch((error) => {
-  console.log(`\n${chalk.red(error)}\n`);
+webpack(webpackConfig, (err,stats) => {
+  if (err) throw err;
+  console.log(`${stats.toString({
+    colors: true,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false,
+  })}`);
+  console.log('');
+  
+  
+  const deploy = argv.replace ? replace : upload;
+  
+  continueIfPulishedTheme().then((answer: boolean) => {
+    if (!answer) {
+      process.exit(0);
+    }  
+    return deploy();
+  }).then(() => {
+    return console.log(chalk.green('\nFiles overwritten successfully!\n'));
+  }).catch((error) => {
+    console.log(`\n${chalk.red(error)}\n`);
+  });
 });

--- a/packages/slate-tools/src/schema.ts
+++ b/packages/slate-tools/src/schema.ts
@@ -3,8 +3,9 @@ import * as os from 'os';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano'
 import { SchemaPaths, SCHEMA_PATHS, slateConfigCreate, slateSchemaCreate } from '@process-creative/slate-config';
+import { SchemaEnv, SCHEMA_ENV } from '@process-creative/slate-env';
 
-export type SchemaTools = SchemaPaths & {
+export type SchemaTools = SchemaPaths & SchemaEnv & {
   /** Enable/disable the prompt to skip uploading settings_data.json */
   'cli.promptSettings':boolean;
 
@@ -86,7 +87,7 @@ export type SchemaTools = SchemaPaths & {
 
 //Encapsulating to preserve type definitioxns
 export const SCHEMA_TOOLS = slateSchemaCreate<SchemaTools>(config => ({
-  ...SCHEMA_PATHS(config),
+  ...SCHEMA_ENV(config),
   
   'cli.promptSettings': true,
 


### PR DESCRIPTION
As stated above, this PR enables support for Slate to have separated webpack distributions per environment. Because the env is based on the CLI arguments and the current, default deploy task puts the cli args _only_ on the deploy command, this will require the script in your themes to require an update;

Before:
`"deploy": "slate-tools build && slate-tools deploy"`

After:
`"deploy": "slate-tools deploy"`
