### PR TITLE
Js cli

### DIFF
--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -2,7 +2,7 @@
   "name": "@process-creative/slate-tools",
   "version": "2.1.52",
   "bin": {
-    "slate-tools": "./src/cli/index.ts"
+    "slate-tools": "./dist/cli/index.js"
   },
   "scripts": {
     "build": "npm run tsc",
@@ -53,7 +53,7 @@
     "fs-extra": "9.0.1",
     "html-loader": "1.3.2",
     "html-webpack-include-assets-plugin": "2.0.0",
-    "html-webpack-plugin": "4.5.2",
+    "html-webpack-plugin": "4.5.0",
     "img-loader": "3.0.1",
     "inquirer": "7.3.3",
     "ip": "1.1.5",

--- a/packages/slate-tools/src/cli/index.ts
+++ b/packages/slate-tools/src/cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-script
+#!/usr/bin/env node
 import spawn from 'cross-spawn';
 import chalk from 'chalk';
 import minimist from 'minimist';


### PR DESCRIPTION
Switched the CLI commands back over to JavaScript to help with issues that some of the webpack plugins were having throwing type errors in production