### PR TITLE
pictureGenerate: resolve src string closing quote

### DIFF
--- a/packages/slate-theme-tools/src/image/index.ts
+++ b/packages/slate-theme-tools/src/image/index.ts
@@ -117,7 +117,7 @@ export const pictureGenerate = (params:GenPictureParams) => {
 
     //Generate media sources
     sizes.forEach((size,si) => {
-      const isLast = si === params.sizes.length - 1;
+      const isLast = si === sizes.length - 1;
 
       buffer += '<source media="';
       if(typeof size.screen === 'string') {
@@ -134,11 +134,12 @@ export const pictureGenerate = (params:GenPictureParams) => {
         let imageSize = size.size;
         if(typeof size.size === 'number') imageSize = size.size * r;
         buffer += getImageUrl(params.src, imageSize);
-        buffer += `${versionNumber? `?v=${versionNumber}` : ``}"`;
+        buffer += `${versionNumber? `?v=${versionNumber}` : ``}`;
         if(r != 1) buffer += ` ${r}x`;
         if(y < (ratios.length-1)) buffer += ', ';
       });
 
+      buffer += `"`;
       if(params.alt) buffer += `alt="${params.alt}" `;
       if(params.lazy && params.lazy.dataSizes) buffer += `data-sizes="auto" `;
       buffer += '/>';


### PR DESCRIPTION
## Reason for Pull Request
It was noticed that the picture tool was not printing the source src values correctly, closing the quote before the other ratio was added. 
![image](https://user-images.githubusercontent.com/48736634/140457790-dc82fda5-9359-492e-b404-73ae4d128a9c.png)

## Pull Request Changes
Moved the close bracket and also rectified the reference to the last index of the array. 

## Meta Information
Type: 🐛 
Asana Card: N/A
Theme Preview: Added the function to the source of the AK Racing site for testing. See it on the collection page when you change page or filter: https://ak-racing.com.au/collections/all?preview_theme_id=127203016884