### PR TITLE
cartChange ID can be a string if line_item.key

### DIFF
--- a/src/cart/change.ts
+++ b/src/cart/change.ts
@@ -5,7 +5,7 @@ export type CartChange = {
   quantity?:number;
   properties?:LineItemProperties;
 } & (
-  { line:number; } | { id:number; }
+  { line:number; } | { id:number|string; }
 );
 export class EventCartChanged extends CustomEvent<{ cart:Cart }> {
   constructor(cart:Cart) {


### PR DESCRIPTION
## Reason for Pull Request
Needed to use line_item.key with the cartChange method.

## Pull Request Changes
Added string to the id type.

## Meta Information
Type: change