### PR TITLE
Cart Remove 

### DIFF
--- a/src/cart/remove.ts
+++ b/src/cart/remove.ts
@@ -1,6 +1,6 @@
 import { cartChange, cartGetCurrent, cartUpdate } from "./";
 
-export const cartRemove = (line:number) => cartChange({ line, quantity: 0 });
+export const cartRemove = (line:number|string) => cartChange({ id: line, quantity: 0 });
 
 export const cartRemoveLines = (lines:number[]) => cartUpdate({
   updates: cartGetCurrent().items.reduce((x,y,i) => {


### PR DESCRIPTION
## Reason for Pull Request
Updated new cartRemove function to accept item key or ID. Key saves accidentally removing the incorrect item if the second one is triggered before the first one has finished.