### PR TITLE
Added additional url parsing code to remove un-needed size params

### DIFF
--- a/src/image/__tests__/index.ts
+++ b/src/image/__tests__/index.ts
@@ -1,0 +1,19 @@
+import { pictureGenerate } from './../index';
+
+describe('pictureGenerate', () => {
+  it('work', () => {
+
+    expect(pictureGenerate({
+      src: 'https://cdn.shopify.com/s/files/1/1099/4438/products/all-belts-007_350x403.jpg?v=1575931882',
+      srcSize: 600,
+      class: 'o-product-tile__image-picture',
+      sizes: [
+        { size: 375 },
+        { size: 300, screen: 480 },
+        { size: 300, screen: 2000 }
+      ]
+    })).toEqual('');
+
+  });
+
+});

--- a/src/image/picture.ts
+++ b/src/image/picture.ts
@@ -94,7 +94,6 @@ export const pictureGenerate = (params:GenPictureParams) => {
         let imageSize = size.size;
         if(typeof size.size === 'number') imageSize = size.size * r;
         buffer += getImageUrl(params.src, imageSize);
-        console.log(getImageUrl(params.src, imageSize));
         buffer += `${versionNumber? `?v=${versionNumber}` : ``}`;
         if(r != 1) buffer += ` ${r}x`;
         if(y < (ratios.length-1)) buffer += ', ';

--- a/src/image/picture.ts
+++ b/src/image/picture.ts
@@ -57,6 +57,14 @@ export const pictureGenerate = (params:GenPictureParams) => {
   if(typeof params['cloudinarySrc'] !== typeof undefined) {
     params.src = params['cloudinarySrc']!;
   }
+  // @ts-ignore
+  let [ url, query ] = params.src.split('?');
+  const size = url.split('_')[1]?.split('.')[0];
+
+  url = url.replace(`_${size}`, '');
+  url = `${url}?${query}`;
+
+  params.src = url;
 
   //Random version number, used to disable cache
   const versionNumber = params.cache == false ? Math.floor(Math.random() * 1000000000) : '';
@@ -86,6 +94,7 @@ export const pictureGenerate = (params:GenPictureParams) => {
         let imageSize = size.size;
         if(typeof size.size === 'number') imageSize = size.size * r;
         buffer += getImageUrl(params.src, imageSize);
+        console.log(getImageUrl(params.src, imageSize));
         buffer += `${versionNumber? `?v=${versionNumber}` : ``}`;
         if(r != 1) buffer += ` ${r}x`;
         if(y < (ratios.length-1)) buffer += ', ';

--- a/src/url/index.ts
+++ b/src/url/index.ts
@@ -102,7 +102,6 @@ export const getImageUrl = (src:ImageSource|null, size:ShopifyImageSize|null):st
   let match = strSrc.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
   if (!match) return null;
 
-
   let prefix = strSrc.split(match[0]);
   let suffix = match[0];
   return removeProtocol([


### PR DESCRIPTION
## Why?

Shopify changed the format of the image urls which was breaking our pictureGenerate tool, used across many different clients

## What was changed?
* removed size params from image url

