### PR TITLE
Removed additional which removes query param. It looks like shopify h…

### DIFF
--- a/src/image/picture.ts
+++ b/src/image/picture.ts
@@ -57,15 +57,7 @@ export const pictureGenerate = (params:GenPictureParams) => {
   if(typeof params['cloudinarySrc'] !== typeof undefined) {
     params.src = params['cloudinarySrc']!;
   }
-  // @ts-ignore
-  let [ url, query ] = params.src.split('?');
-  const size = url.split('_')[1]?.split('.')[0];
-
-  url = url.replace(`_${size}`, '');
-  url = `${url}?${query}`;
-
-  params.src = url;
-
+  
   //Random version number, used to disable cache
   const versionNumber = params.cache == false ? Math.floor(Math.random() * 1000000000) : '';
 

--- a/src/url/index.ts
+++ b/src/url/index.ts
@@ -99,7 +99,7 @@ export const getImageUrl = (src:ImageSource|null, size:ShopifyImageSize|null):st
     }
   }
 
-  let match = strSrc.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
+  let match = strSrc.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?.+)?$/i);
   if (!match) return null;
 
   let prefix = strSrc.split(match[0]);


### PR DESCRIPTION
Shopify appears to have changed everything back, so removing the code that we initially changed was all that was required (I think).

This still needs to be tested across the wider range of clients, however when I was fixing this I did some quick tests across Rollie, SMAI Bored Cow and Helly Hansen as these were some of the main clients experiencing issues.

In order to test:

1. Pull down this repository
2. Run yarn install and yarn build
3. Copy the dist folder
4. Open up repository of the client we want to test
5. Replace the @process-creative/slate-theme-tools/dist folder with the one out of the freshly built repo
6. Run yarn build
7. Uncomment any previously commented out pictureGenerate methods.
8. Check the sections where they are being used in a local dev environment

In the event that an image is not being displayed correctly, can you please provide the following:
* The image URL as it is being passed to the pictureGenerate method(you can console log this out)
* The markup that is returned from the pictureGenerate method(Clog this out too)
* The url of the page that you saw this on